### PR TITLE
Updates to CloudWatch guides. 

### DIFF
--- a/sphinx_shared/_includes/common_includes.txt
+++ b/sphinx_shared/_includes/common_includes.txt
@@ -422,10 +422,10 @@
 .. |CT-ug| replace:: :title:`CloudTrail User Guide`
 .. |CW-api| replace:: :title:`CloudWatch API Reference`
 .. |CW-cli| replace:: :title:`CloudWatch CLI Reference`
-.. |CW-dg| replace:: :title:`CloudWatch Developer Guide`
+.. |CW-ug| replace:: :title:`CloudWatch User Guide`
+.. |CW-dg| replace:: :title:`CloudWatch User Guide`
 .. |CW-gsg| replace:: :title:`CloudWatch Getting Started Guide`
 .. |CW-qrc| replace:: :title:`CloudWatch Quick Reference Card`
-.. |CW-ug| replace:: :title:`CloudWatch User Guide`
 .. |CWE-api| replace:: :title:`CloudWatch Events API Reference`
 .. |CWE-ug| replace:: :title:`CloudWatch Events User Guide`
 .. |CWL-api| replace:: :title:`CloudWatch Logs API Reference`

--- a/sphinx_shared/_includes/guide_links.txt
+++ b/sphinx_shared/_includes/guide_links.txt
@@ -67,12 +67,15 @@
 .. _CT-ug: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/
 .. _CW-api: https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/
 .. _CW-cli: https://docs.aws.amazon.com/AmazonCloudWatch/latest/cli/
-.. _CW-dg: https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/
+.. _CW-ug: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/
+.. _CW-dg: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/
 .. _CW-gsg: https://docs.aws.amazon.com/AmazonCloudWatch/latest/GettingStartedGuide/
 .. _CWE-api: https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/
+.. _CWE-ug: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/
 .. _CWE-dg: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/
 .. _CWL-api: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/
-.. _CWL-dg: https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/
+.. _CWL-ug: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/
+.. _CWL-dg: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/
 .. _DDB-api: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/
 .. _DDB-dg: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/
 .. _DDB-gsg: https://docs.aws.amazon.com/amazondynamodb/latest/gettingstartedguide/


### PR DESCRIPTION
I've created a couple of new links and replacements to try and straighten out the CloudWatch doc links. There are (no longer) dev guides, but user guides for CW, CW Events, and CW Logs.

I've left the *-dg guide link entries in place so as to not break exisitng doc sets until they can replace with *-ug. I modified the link values to point at valid base URLs for *-dg entries.

Make sense?