### PR TITLE
Removed a substitution for a guide that no longer exists.

### DIFF
--- a/sphinx_shared/_includes/common_includes.txt
+++ b/sphinx_shared/_includes/common_includes.txt
@@ -577,7 +577,6 @@
 .. |SP-ug| replace:: :title:`Amazon Simple Pay Advanced User Guide`
 .. |SQS-api| replace:: :title:`Amazon SQS API Reference`
 .. |SQS-dg| replace:: :title:`Amazon SQS Developer Guide`
-.. |SQS-gsg| replace:: :title:`Amazon SQS Getting Started Guide`
 .. |SQS-qrc| replace:: :title:`Amazon SQS Quick Reference Card`
 .. |SSM-api| replace:: :title:`SSM API Reference`
 .. |STS-api| replace:: :title:`AWS STS API Reference`


### PR DESCRIPTION
The _Amazon SQS Getting Started Guide_ has been retired. The most current information is in the _Amazon SQS Developer Guide_: http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-tutorials.html