### PR TITLE
Adding AWS entity

### DIFF
--- a/sphinx_shared/_includes/common_includes.txt
+++ b/sphinx_shared/_includes/common_includes.txt
@@ -34,6 +34,7 @@
    ------------------------------
 .. |arnlong| replace:: Amazon Resource Name
 .. |AWSlong| replace:: Amazon Web Services
+.. |AWS| replace:: Amazon Web Services
 .. |JSONlong| replace:: JavaScript Object Notation
 .. |aws-accesskey-var| replace:: :code:`AWS_ACCESS_KEY_ID`
 .. |aws-configfile-loc-unixes| replace:: :file:`~/.aws/config`


### PR DESCRIPTION
The |AWS| entity is referenced in other entities (such as procedure-get-access-keys.txt), so builds are breaking without it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
