### PR TITLE
Adding link to S3 and EC2 documentation landing pages

### DIFF
--- a/sphinx_shared/_includes/guide_links.txt
+++ b/sphinx_shared/_includes/guide_links.txt
@@ -13,6 +13,13 @@
    None of these should have anything after the final '/' character (and all of
    them should include it), they're used to generate extlinks for the guides.
 
+.. Service and SDK doc landing page links
+   --------------------------------------
+.. |ec2-doc-landing| replace :: Amazon EC2 Documentation 
+.. _ec2-doc-landing: https://aws.amazon.com/documentation/ec2/
+.. |s3-doc-landing| replace :: Amazon S3 documentation
+.. _s3-doc-landing: http://aws.amazon.com/documentation/s3/
+
 .. Service Guide links
    -------------------
 .. _AAS-dg: https://docs.aws.amazon.com/appstream/latest/developerguide/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the Python SDK code samples there are links to find more information in the AWS service's documentation landing page. Since these two services have multiple guides these links will expose all the resources available to developers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
