### PR TITLE
removing space, so that entity will resolve

### DIFF
--- a/sphinx_shared/_includes/guide_links.txt
+++ b/sphinx_shared/_includes/guide_links.txt
@@ -15,9 +15,9 @@
 
 .. Service and SDK doc landing page links
    --------------------------------------
-.. |ec2-doc-landing| replace :: Amazon EC2 Documentation 
+.. |ec2-doc-landing| replace:: Amazon EC2 Documentation 
 .. _ec2-doc-landing: https://aws.amazon.com/documentation/ec2/
-.. |s3-doc-landing| replace :: Amazon S3 documentation
+.. |s3-doc-landing| replace:: Amazon S3 Documentation
 .. _s3-doc-landing: http://aws.amazon.com/documentation/s3/
 
 .. Service Guide links


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Unable to build package because "Substitution definition "s3-doc-landing" empty or invalid."
Caused by space between replace and ::


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
