### PR TITLE
Update common_includes.txt

### DIFF
--- a/sphinx_shared/_includes/common_includes.txt
+++ b/sphinx_shared/_includes/common_includes.txt
@@ -971,10 +971,10 @@
 .. |sdk-ios-api| replace:: :title:`AWS Mobile SDK for iOS API Reference`
 .. |sdk-ios-dg| replace:: :title:`AWS Mobile SDK for iOS Developer Guide`
 .. |sdk-ios-gsg| replace:: :title:`AWS Mobile SDK for iOS Getting Started Guide`
-.. |sdk-java-api| replace:: :title:`AWS SDK for Java API Reference`
-.. |sdk-java-api-v2| replace:: :title:`AWS SDK for Java 2.0 API Reference`
-.. |sdk-java-dg| replace:: :title:`AWS SDK for Java Developer Guide`
-.. |sdk-java-dg-v2| replace:: :title:`AWS SDK for Java 2.0 Developer Guide`
+.. |sdk-java-api| replace:: :title:`AWS SDK for Java 1.x API Reference`
+.. |sdk-java-api-v2| replace:: :title:`AWS SDK for Java 2.x API Reference`
+.. |sdk-java-dg| replace:: :title:`AWS SDK for Java 1.x Developer Guide`
+.. |sdk-java-dg-v2| replace:: :title:`AWS SDK for Java 2.x Developer Guide`
 .. |sdk-java-ref| replace:: |sdk-java-api|
 .. |sdk-java-ref-v2| replace:: |sdk-java-api-v2|
 .. |sdk-js-dg| replace:: :title:`AWS SDK for JavaScript Developer Guide`


### PR DESCRIPTION
Update includes for SDK for Java to match marketing pages and product documentation

*Description of changes:*
Change "2.0" to "2.x" for v2 includes and add "1.x" to v1 includes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
